### PR TITLE
fix compilation errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 #CC      =   gcc
-CFLAGS  =	-Wall -O3 -Wno-unused-variable -Wno-unused-function -Wno-misleading-indentation -DUSE_SIMDE -DSIMDE_ENABLE_NATIVE_ALIASES
+CFLAGS  =	-std=gnu99 -Wall -O3 -Wno-unused-variable -Wno-unused-function -Wno-misleading-indentation -DUSE_SIMDE -DSIMDE_ENABLE_NATIVE_ALIASES
 
 # for debug
 ifneq ($(debug),)


### PR DESCRIPTION
On a Linux machine, with different versions of GCC (7, 8, 11), compilation ends with errors. Indicating that the C code follows the C99 standard with some GNU extensions (for pthreads) allows compilation to go through.