### PR TITLE
Update .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "abPOA"]
 	path = abPOA
-	url = git@github.com:yangao07/abPOA.git
+	url = https://github.com/yangao07/abPOA.git
     ignore = dirty


### PR DESCRIPTION
Use `https` rather than `git` protocol to avoid the following error when running `git clone --recursive`:

```
Submodule 'abPOA' (git@github.com:yangao07/abPOA.git) registered for path 'abPOA'
Cloning into 'abPOA'...
Permission denied (publickey).
fatal: Could not read from remote repository.
```